### PR TITLE
Add Merkle Root library link

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ A curated list of resources for learning and programming in Noir.
 - [Sparse Merkle Tree Verifier](https://github.com/vocdoni/smtverifier-noir/tree/main) - a library for verification of sparse Merkle trees
 - [Signed Int](https://github.com/resurgencelabs/signed_int) - a library for accessing a custom Signed Integer data type, allowing access to negative numbers on Noir
 - [Fraction](https://github.com/resurgencelabs/fraction) - a library for accessing fractional number data type in Noir, allowing results that aren't whole numbers
-- [RSA](https://github.com/SetProtocol/noir-rsa) - This repository contains an implementation of a RSA signature verify for the Noir language. 
+- [RSA](https://github.com/SetProtocol/noir-rsa) - This repository contains an implementation of a RSA signature verify for the Noir language.
+- [Merkle Root](https://github.com/tomoima525/noir-merkle-root) - a library for calculating Merkle root from given inputs. Using the Poseidon function for hashing.
 
 
 ## Projects


### PR DESCRIPTION

# Description

Add a link to the Merkle Root library.


## Problem\*

NA

## Summary\*

Noir Merkle Root is a function for calculating merkle root from given inputs. It is used in https://github.com/knot-inc/noxx-contract for proving the residency of user's country

# PR Checklist\*

- [-] I have tested the changes locally.
- [-] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
