### PR TITLE
Add base64 to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ A curated list of resources for learning and programming in Noir.
 ### Libraries
 
 - [Standard Library](https://github.com/noir-lang/noir/tree/master/noir_stdlib) - the Noir Standard Library
+- [Base64](https://github.com/zkworks-xyz/noir-base64) - a library for base64 encoding
 
 #### Types
 


### PR DESCRIPTION
# Description
Add link to base64 encoding library. I'm not sure if this kind of library should be under general _Libraries_ section or maybe create another subsection for example _Encoding_ or _Serialization_.
