### PR TITLE
Update Base64 library url

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A curated list of resources for learning and programming in Noir.
 ### Libraries
 
 - [Standard Library](https://github.com/noir-lang/noir/tree/master/noir_stdlib) - the Noir Standard Library
-- [Base64]([https://github.com/zkworks-xyz/noir-base64](https://github.com/vlayer-xyz/noir-base64)) - a library for base64 encoding
+- [Base64](https://github.com/vlayer-xyz/noir-base64) - a library for base64 encoding
 - [Complex Numbers](https://github.com/doctoruber/complexnr) - This library offers a comprehensive suite of operations for complex numbers.
 - [Fixed Point Library](https://github.com/doctoruber/noir-fixed-point) - The FixedPoint library offers precise fixed-point arithmetic operations tailored for Noir.
 - [Statistical Library](https://github.com/doctoruber/statnr) - Noir Statistical Library is a comprehensive library for statistical computations in the Noir language.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A curated list of resources for learning and programming in Noir.
 ### Libraries
 
 - [Standard Library](https://github.com/noir-lang/noir/tree/master/noir_stdlib) - the Noir Standard Library
-- [Base64](https://github.com/zkworks-xyz/noir-base64) - a library for base64 encoding
+- [Base64]([https://github.com/zkworks-xyz/noir-base64](https://github.com/vlayer-xyz/noir-base64)) - a library for base64 encoding
 - [Complex Numbers](https://github.com/doctoruber/complexnr) - This library offers a comprehensive suite of operations for complex numbers.
 - [Fixed Point Library](https://github.com/doctoruber/noir-fixed-point) - The FixedPoint library offers precise fixed-point arithmetic operations tailored for Noir.
 - [Statistical Library](https://github.com/doctoruber/statnr) - Noir Statistical Library is a comprehensive library for statistical computations in the Noir language.


### PR DESCRIPTION
We changed our GitHub and so url of noir-base64 has changed