### PR TITLE
feat: dimensionless BigUint data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ A curated list of resources for learning and programming in Noir.
 ##### Numerics
 
 - [BigInt](https://github.com/shuklaayush/noir-bigint) - a library that provides a custom BigUint56 data type, allowing for computations on large unsigned integers
+- [BigUint](https://github.com/distributed-lab/noir-plume/blob/main/crates/plume/src/biguint.nr) - a file that provides a custom BigUint data type, allowing to perform calculations with dimensionless unsigned integers
 - [Fraction](https://github.com/resurgencelabs/fraction) - a library for accessing fractional number data type in Noir, allowing results that aren't whole numbers
 - [ZKFloat](https://github.com/0x3327/ZKFloat) - a floating point library for Noir
 - [Complex Numbers](https://github.com/doctoruber/complexnr) - This library offers a comprehensive suite of operations for complex numbers


### PR DESCRIPTION
# Description

## Problem\*
Currently, there is only a BigUint library with a limited byte size

Resolves <!-- Link to GitHub Issue -->

## Summary\*
Add a dimensionless BigUint class


## Additional Context
No additional context


# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
