### PR TITLE
chore: update readme with nova and hypernova as proving backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A curated list of resources for learning and programming in Noir.
 - [Halo2](https://github.com/Ethan-000/halo2_backend) by Ethan (needs updating?)
 - [Groth16](https://github.com/TomAFrench/acvm-backend-groth16) (needs updating)
 - [Marlin](https://github.com/noir-lang/marlin_arkworks_backend) (needs updating)
+- [Nova, HyperNova](https://github.com/privacy-scaling-explorations/sonobe/tree/main) by 0xPARC and PSE
 
 ### Libraries
 


### PR DESCRIPTION
# Description

We integrated `noir` as a frontend to [`sonobe`](https://github.com/privacy-scaling-explorations/sonobe), a library being joint-developed by [0xPARC](https://github.com/0xPARC) and [PSE](https://github.com/privacy-scaling-explorations). It  implements various folding schemes such as [nova](https://eprint.iacr.org/2021/370) and [hypernova](https://eprint.iacr.org/2023/573), with which `noir` circuits can be folded. It includes some [example](https://github.com/privacy-scaling-explorations/sonobe/blob/main/examples/noir_full_flow.rs) code showing how to do this using nova.