### PR TITLE
Fix typo: in Sparse Merkle Tree description

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 - [Merkle Root](https://github.com/tomoima525/noir-merkle-root) - calculating Merkle root from given inputs of a Poseidon based Merkle tree
 - [Sparse Merkle Tree Implementation](https://github.com/jordan-public/zk-optimized-sparse-merkle-tree) - TypesSript library to generate optimized sparse merkle trees
 - [Sparse Merkle Tree Verifier](https://github.com/vocdoni/smtverifier-noir) - verification of sparse Merkle trees
-- [Sparse Merkle Tree Verify/Add/Update/Delete](https://github.com/privacy-scaling-explorations/zk-kit.noir/tree/main/packages/merkle-trees) - verification of (non-)membership proofs and add/update/delete leafs
+- [Sparse Merkle Tree Verify/Add/Update/Delete](https://github.com/privacy-scaling-explorations/zk-kit.noir/tree/main/packages/merkle-trees) - verification of (non-)membership proofs and add/update/delete leaves
 
 #### Message Authentication Code
 


### PR DESCRIPTION
**Description**:  
Replaced the incorrect plural form of "leaf" (**leafs**) with the proper grammatical form (**leaves**) in the Sparse Merkle Tree section. This change aligns with standard English usage and ensures consistency across technical documentation.

**Why this matters**:  
Correct terminology improves clarity, especially for developers working with Merkle Trees or other data structures involving "leaves."

**Examples of proper usage**:  
1. **Incorrect**: "Add or update the **leafs** in the Merkle Tree."  
   **Correct**: "Add or update the **leaves** in the Merkle Tree."

2. **Incorrect**: "The tree structure contains multiple **leafs**."  
   **Correct**: "The tree structure contains multiple **leaves**."
