### PR TITLE
docs: fixed Twitter link inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A curated list of resources for learning and programming in Noir.
 ⚠️ This repository or the contained links are not endorsed as safe and secure by Aztec Labs or the Noir team. Users are advised to exercise caution before utilizing any content or code provided herein.
 
 [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
-[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/Noir.svg?style=social&label=Follow%20%40Noir)](https://twitter.com/NoirLang)
+[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/NoirLang.svg?style=social&label=Follow%20%40Noir)](https://twitter.com/NoirLang)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A curated list of resources for learning and programming in Noir.
 ⚠️ This repository or the contained links are not endorsed as safe and secure by Aztec Labs or the Noir team. Users are advised to exercise caution before utilizing any content or code provided herein.
 
 [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
-[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/NoirLang.svg?style=social&label=Follow%20%40Noir)](https://twitter.com/NoirLang)
+![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/NoirLang)
 
 ---
 


### PR DESCRIPTION
# Description

 I noticed that the Twitter link in the text points to `https://twitter.com/NoirLang`, but the mention in the text is `@Noir`, this inconsistency could confuse readers.

I've updated the link to match the mention, ensuring clarity and accuracy.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
