### PR TITLE
Fix noir-libs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 #### Library Registry
 
 - [Noir Directory](https://noir.directory) by Oleh
-- [npkg](https://npkg.walnut.dev/) by Walnut
+- [Noir Libs](https://noir-libs.org/) by Walnut
 
 #### CLI Manager
 
-- [npkg](https://github.com/walnuthq/noir/tree/feat/package_cmd2) by Walnut
+- [noir-libs](https://github.com/walnuthq/noir-libs) by Walnut
 
 ### IDE
 


### PR DESCRIPTION
# Description
Update references to noir-libs (deployed at noir-libs.org) by Walnut.

## Problem

The README contained links to the POC, initially hosted by Walnut at npkg.walnut.dev

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
