### PR TITLE
Add coNoir/coSNARKs as a proving backend as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 - [Plonky2](https://github.com/blocksense-network/noir) by Blocksense
 - [Plonky2](https://github.com/eryxcoop/acvm-backend-plonky2) by Eryx
 - [Sonobe (Nova, HyperNova)](https://github.com/privacy-scaling-explorations/sonobe) by 0xPARC and PSE
+- [coSNARKs](https://github.com/TaceoLabs/co-snarks) by Taceo Labs
 - [Plonky3](https://github.com/vacekj/air-fried-gyatt) by Josef (needs updating)
 - [Halo2](https://github.com/Ethan-000/halo2_backend) by Ethan (needs updating)
 - [Groth16](https://github.com/TomAFrench/acvm-backend-groth16) (needs updating)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 
 ### Private shared states
 
-- [coNoir](https://github.com/TaceoLabs/co-snarks) - generate witness and prove Noir programs in a Multi-Party Computation network
+- [coSNARKs](https://github.com/TaceoLabs/co-snarks) - generate witness and prove Noir programs in a Multi-Party Computation network
 - [Kalypso](https://docs.marlin.org/user-guides/kalypso/tutorials/noir-circuits/) - generate witness and prove Noir programs in Trusted Execution Environments
 
 ### Library-related


### PR DESCRIPTION
# Description

## Problem\*

coSNARKs are also a proving backend for Noir, but are currently only listed under [Private Shared States](https://github.com/noir-lang/awesome-noir/tree/main?tab=readme-ov-file#private-shared-states)

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
