### PR TITLE
chore: update Rate-Limiting Nullifier link

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 ### Social
 
 - [anon.world](https://github.com/Slokh/anonworld) - social media with optional anonymity
-- [Rate Limiting Nullifiers](https://github.com/Rate-Limiting-Nullifier/noir-rln) - spam regulation in anonymous environments
+- [Rate Limiting Nullifiers](https://github.com/curryrasul/rln.nr) - spam regulation/rate-limiting in anonymous environments
 - [StealthNote](https://github.com/saleel/stealthnote) - message board for people in an organization to anonymously broadcast messages
 
 ### Miscellaneous


### PR DESCRIPTION
# Description

Updated the link for Noir implementation from the old one: https://github.com/Rate-Limiting-Nullifier/noir-rln
to the new one: https://github.com/curryrasul/rln.nr

---

The updated link contains implementation for both circuits ([main one for signalling](https://github.com/Rate-Limiting-Nullifier/circom-rln/blob/main/circuits/rln.circom), and [second one for withdraw](https://github.com/Rate-Limiting-Nullifier/circom-rln/blob/main/circuits/withdraw.circom))

---

[WIP]:
* Registry contract in Solidity with updated verifier
* Example app
