### PR TITLE
fix(docs): removed the link to YouTube that didn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,6 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
   - Simple demo and test
 - [20 mins] [Private Value Transfer in 10 Lines](https://www.youtube.com/watch?v=wYqqXas8_O4) ([Source Code](https://github.com/vezenovm/simple_shield))
   - Tornado-like private asset transfer using Merkle proofs
-- [25 mins] [Noir as a Smart Contract Language](https://www.youtube.com/watch?v=tYdUaCbACtk)
-  - Noir as the smart contract language for the Aztec rollup
-  - Noir smart contracts
 - [45 mins] [Outlandish Noir Stuff; Workshop at ETHCC](https://www.youtube.com/watch?v=pdrZ7Y__obU)
   - How to use Noir to build a bunch of outlandish stuff
 - [1 hr] [Circuit Safety and an Introduction to Noir](https://www.youtube.com/watch?v=rLvu61DA-hk)


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
