### PR TITLE
Add Noir Static Analyzer to Dev Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 - [Tree-sitter-noir](https://github.com/hhamud/tree-sitter-noir) - Tree-sitter grammar for Noir language
 - [Emacs Tree-sitter Plugin](https://melpa.org/#/noir-ts-mode) - Syntax highlight ([Source Code](https://github.com/hhamud/noir-ts-mode))
 
+### Tooling
+
+- [Noir Static Analyzer](https://github.com/walnuthq/noir-static-analyzer) by Walnut
+
 ### Performance
 
 - [Noir + Barretenberg Profiler](https://github.com/noir-lang/noir/tree/master/tooling/profiler) - Opcode, execution and proving costs flamegraphing tool

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 - [Tree-sitter-noir](https://github.com/hhamud/tree-sitter-noir) - Tree-sitter grammar for Noir language
 - [Emacs Tree-sitter Plugin](https://melpa.org/#/noir-ts-mode) - Syntax highlight ([Source Code](https://github.com/hhamud/noir-ts-mode))
 
-### Tooling
+### Linting
 
 - [Noir Static Analyzer](https://github.com/walnuthq/noir-static-analyzer) by Walnut
 


### PR DESCRIPTION
# Description

Added the Noir Static Analyzer to the list of available Noir tooling.

I didn’t find an existing category that fit well, so I created a new one called **Tooling**. I considered placing it under **Security**, but based on the current items in that category, it didn’t feel like the right fit.

Open to suggestions if there’s a better place for it.