### PR TITLE
[README.nd]: edit link to BattleZips

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Click the hamburger button slightly upper-right from here to access the table of
 
 ### Gaming
 
-- [BattleZips](https://battlezips.com/) ([Source Code](https://github.com/BattleZips/BattleZips-Noir)) - on-chain Battleship
+- [BattleZips](https://github.com/BattleZips/BattleZips-Noir) - on-chain Battleship
 - [Dappicom](https://github.com/tonk-labs/dappicom) - Nintendo Entertainment System (NES) emulator in Noir for proofs of gameplays / speedruns
 - [zk-hangman-noir](https://github.com/Turupawn/zk-hangman-noir) - end-to-end zkDApp demo showcasing the Hangman circuit, EVM contract, and WASM frontend
 


### PR DESCRIPTION
# Description

## Problem

There are no more workful link to BattleZips's site so i think we need to replace it by link to their repo. There users can find guide how to set up BattleZips-Noir from scratch

## Summary



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
