### PR TITLE
Fix double space in Lib_LinkList description

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 
 - [Sort](https://github.com/noir-lang/noir_sort) - efficient sorting of fixed-sized arrays
 - [Sparse Array](https://github.com/noir-lang/sparse_array) - efficient immutable and mutable sparse arrays
-- [Lib_LinkList](https://github.com/0xKarl98/Lib_LinkList) - A memory-efficient doubly-linked list implementation for Noir that supports constant  time operations at both ends
+- [Lib_LinkList](https://github.com/0xKarl98/Lib_LinkList) - A memory-efficient doubly-linked list implementation for Noir that supports constant time operations at both ends
 
 ### Cryptography
 


### PR DESCRIPTION
# Description

Remove the extra space between "constant" and "time" in the Lib_LinkList library description.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
