### PR TITLE
Add prove_threshold_policy under Identity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Click the hamburger button slightly upper-right from here to access the table of
 - [Self](https://github.com/selfxyz/self) - identity wallet supporting privacy-preserving proofs of government-issued IDs
 - [ZKPassport](https://github.com/zkpassport/) - privacy-preserving proofs of national passports
 - [Rarimo](https://github.com/rarimo/passport-zk-circuits-noir) - passport signature verification circuits
+- [prove_threshold_policy](https://github.com/cypriansakwa/prove_threshold_policy) – A Noir circuit that proves threshold policy compliance without revealing the private input. Useful for access control, recovery, and identity gating.
+
 
 ### Social
 


### PR DESCRIPTION
# Description

Adds the [`prove_threshold_policy`](https://github.com/cypriansakwa/prove_threshold_policy) Noir circuit to the **Identity** section of the Awesome Noir list.

This circuit enables threshold-based verification without revealing the private input — useful for privacy-preserving identity validation, access control, or social recovery flows.

## Problem

Resolves: _Not tied to a specific issue_ — contributes to enriching the ecosystem with real-world Noir examples.

## Summary

- Added a new project under `Projects > Identity` in `README.md`
- The project implements a Noir circuit that enforces:
2 * secret_share + public_offset == 17

- The goal is to allow a prover to demonstrate they meet a predefined threshold **without revealing their actual secret value**.

## Additional Context

This circuit is designed to showcase a common policy-compliance pattern in privacy-focused applications.  
It can serve as a starting point for:
- Zero-knowledge KYC
- Social recovery mechanisms
- Access gating in decentralized apps

---

# PR Checklist
- I have tested the changes locally.
- I have formatted the changes with [Prettier](https://prettier.io/) and/or cargo fmt on default settings.