### PR TITLE
Add ZKModExpCircuit Noir example to Examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Click the hamburger button slightly upper-right from here to access the table of
 - [Self](https://github.com/selfxyz/self) - identity wallet supporting privacy-preserving proofs of government-issued IDs
 - [ZKPassport](https://github.com/zkpassport/) - privacy-preserving proofs of national passports
 - [Rarimo](https://github.com/rarimo/passport-zk-circuits-noir) - passport signature verification circuits
+- [prove_threshold_policy](https://github.com/cypriansakwa/prove_threshold_policy) – A Noir circuit that proves threshold policy compliance without revealing the private input. Useful for access control, recovery, and identity gating.
+
 
 ### Social
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Click the hamburger button slightly upper-right from here to access the table of
 
 - [Noir Examples](https://github.com/noir-lang/noir-examples) - reference examples of zero-knowledge applications in Noir
 - [Circuit Examples](https://github.com/thor314/circuit-examples) - demonstration implementation of dot products & Merkle proofs in Noir, Circom and RISC0
+- [ZKModExpCircuit](https://github.com/cypriansakwa/ZKModExpCircuit) - Modular Exponentiation circuit in Noir with constraint checks and test cases.
+
 
 ### Talks & Workshops
 


### PR DESCRIPTION
# Description

## Problem\*

There is currently no example in the **Examples** section showcasing modular exponentiation in Noir circuits. This addition provides a helpful reference for developers working with arithmetic circuits or cryptographic primitives in Noir.

## Summary\*

This PR adds the following resource to the **Examples** section of the `awesome-noir` repository:

- [ZKModExpCircuit](https://github.com/cypriansakwa/ZKModExpCircuit) — A Noir implementation of modular exponentiation (`mod_exp`) with multiple test cases and constraint checks.

The project demonstrates:
- Modular exponentiation circuit logic
- Public inputs and constraint validation
- Positive and negative test cases, including a `should_fail` test

## Additional Context

This resource is intended for developers learning Noir or building circuits involving arithmetic operations and cryptographic verification. It may also serve as a starting point for more complex zero-knowledge circuits.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

