### PR TITLE
change tree-sitter-noir link

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 - [Neovim Plugin](https://github.com/noir-lang/noir-nvim) - Syntax highlight, error highlight, etc.
 - [Emacs Plugin](https://melpa.org/#/noir-mode) - Syntax highlight ([Source Code](https://github.com/hhamud/noir-mode))
 - [Zed Plugin](https://github.com/shuklaayush/zed-noir) - Syntax highlight, LSP support
-- [Tree-sitter-noir](https://github.com/hhamud/tree-sitter-noir) - Tree-sitter grammar for Noir language
+- [tree_sitter_noir](https://github.com/tsujp/tree_sitter_noir) - Tree-sitter grammar for Noir
 - [Emacs Tree-sitter Plugin](https://melpa.org/#/noir-ts-mode) - Syntax highlight ([Source Code](https://github.com/hhamud/noir-ts-mode))
 
 ### Linting


### PR DESCRIPTION
# Description

## Problem\*

Prior repo (before this commit) is abandon-ware.

## Summary\*

Grammar is nearing completion (and is more complete than prior repo in any case) so I think now is safe to start linking.

## Additional Context

A sanity check on the grammar from a Noir compiler developer would be nice, my requests have mostly fallen on deaf ears.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
