### PR TITLE
add noir-tckn

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A curated list of resources for learning and programming in Noir.
 - [Self](https://github.com/selfxyz/self) - identity wallet supporting privacy-preserving proofs of government-issued IDs
 - [ZKPassport](https://github.com/zkpassport/) - privacy-preserving proofs of national passports
 - [Rarimo](https://github.com/rarimo/passport-zk-circuits-noir) - passport signature verification circuits
+- [noir-tckn](https://github.com/erhant/noir-tckn) – Noir circuit for validating Turkish National Identity Numbers (TCKN) using checksum-based logic.
 
 ### Social
 


### PR DESCRIPTION
# Description

Noir circuit for validating Turkish National Identity Numbers (TCKN) using checksum-based logic.

## Problem\*

Provides a reusable zero-knowledge primitive for validating Turkish citizen IDs on-chain or in private attestations, without leaking the actual identity. Useful for building privacy-preserving identity verification systems or region-specific ZK apps.

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
