### PR TITLE
docs: Fix inconsistent Discord URL formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A curated list of resources for learning and programming in Noir.
 
 - [Docs](https://noir-lang.org/docs)
 - [GitHub](https://github.com/noir-lang)
-- [Discord](https://discord.gg/RJdCBN373S)
+- [Discord](https://discord.com/invite/RJdCBN373S)
 - [Community Job Board](https://www.notion.so/aztecnetwork/Noir-Community-Job-Board-1a1a1f6b0e3580a58515ecae879c8cf2)
 
 ## Projects


### PR DESCRIPTION
# Description

Different domains were used for the same Discord link throughout the documentation (discord.com/invite vs discord.gg). This standardizes all Discord links to use the full discord.com/invite format for consistency.



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
