### PR TITLE
Added wad.nr fixed point library

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 - [Complex Numbers](https://github.com/doctoruber/complexnr) - This library offers a comprehensive suite of operations for complex numbers
 - [Fixed Point Library](https://github.com/doctoruber/noir-fixed-point) - The FixedPoint library offers precise fixed-point arithmetic operations tailored for Noir
 - [Fixed Point Library for scale 2^-16](https://github.com/hashcloak/noir-fixed-point) - an optimized fixed point arithmetic library designed for scale 2^-16.
+- [wad.nr Fixed Point Library](github.com/merkle-groot/wad.nr) - An 18-decimals fixed-point arithmetic library for Noir that enables safe token calculations in DeFi contracts.
 
 #### Dates & Times
 


### PR DESCRIPTION
# Description

A fixed-point library built for DeFi on Noir. Enables safe arithmetic on 18-decimal token amounts which is the foundation for building AMMs, lending markets, or any protocol that handles token math.

## Problem*

Token arithmetic in Noir ZK circuits breaks in two ways:
- Multiplying two 18-decimal token amounts overflows u128 (1000 × 1000 tokens = 10^42)
- Integer division silently truncates precision (1 / 3 = 0 instead of 0.333...)

There was no existing fixed-point math library for Noir targeting DeFi use cases.

## Summary*

Implements a WAD (Wei-As-Decimal) fixed-point arithmetic library with the following:

- `wad_mul_div(a, b, d)` — core primitive, computes `floor(a × b / d)` without intermediate overflow using unconstrained 256-bit long division verified by a single native Field constraint
- `wad_mul` and `wad_div` built on top of `wad_mul_div`
- `wad_add`, `wad_sub`, `to_wad`, `truncate`, `from_u128` utilities
- Input range checks enforcing `< 2^127` to guarantee soundness against BN254 field wrapping
- Full test suite covering arithmetic properties, boundary values, overflow rejection, and ZK soundness edge cases

## Additional Context

- Benchmarked against an equivalent implementation using noir-bignum's U256: ~360 opcodes vs ~4816 opcodes (~13x fewer)
- Safe input ceiling for `wad_mul_div`: `170_141_183_460_469_231_731` (any realistic DeFi token amount)
- Safe input ceiling for `wad_mul(x, x)`: `13_043_817_825`
- Passes Noir's Brillig safety checker: the bignum approach does not for this pattern

# PR Checklist*
- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.