### PR TITLE
chore(readme): add zk proof of liabilities project

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of resources for learning and programming in Noir.
 - [Mist Cash](https://mist.cash/) - private token transfers on StarkNet
 - [Private Tokenised Bonds](https://github.com/Meyanis95/private-tokenised-bonds/) - private institutional bond issuance and settlement
 - [ZK-Flexor](https://zk-flexor.xyz/) - private proofs of EVM asset balances
+- [ZK Proof of Liabilities](https://github.com/ndavd/zk-proof-of-liabilities) - prove to each user of a CEX that their balance is included in the total liabilities without revealing any data from the other users
 
 ### Gaming
 


### PR DESCRIPTION
# Description

A Zero-Knowledge Proof of Liabilities implementation in Noir.

It allows a company to cryptographically prove to each user that their balance is correctly included in its total liabilities without revealing any data from the other users.

## Problem\*

There is no clean, open-source ZK Proof of Liabilities implementation in Noir. The most relevant work on the subject was done by Summa, but the circuits were written in Circom.

## Summary\*

A full end-to-end ZK Proof of Liabilities implementation in Noir, including a reusable `merkle_sum_tree` library crate, a Solidity smart contract for on-chain verification deployed on Sepolia, a TypeScript SDK to facilitate input generation, and a live demo with in-browser proving.

## Additional Context

Inspired by Vitalik Buterin's proposal on proof of solvency: https://vitalik.eth.limo/general/2022/11/19/proof_of_solvency.html

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
