### PR TITLE
Add EIP-712 Noir library

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 #### Ethereum
 
 - [ECrecover](https://github.com/colinnielsen/ecrecover-noir) - ECDSA signature verification and return of source Ethereum address
+- [EIP-712](https://github.com/geovgy/eip712-noir) - A Noir library for EIP-712 typed data hashing
 - [Ethereum MPT Proof](https://github.com/RadNi/mpt-noir) - proving Ethereum Merkle Patricia Trie with recursive proof aggregations
 - [Ethereum Storage Proof](https://github.com/noir-lang/eth-proofs) - proving and verifying historical Ethereum / EVM accounts, storage, logs, receipts & transactions; forked from vlayer-monorepo, updated for compatibility with recent Noir releases, including modernizing outdated patterns
 


### PR DESCRIPTION
Request to add EIP-712 library implemented in Noir. Includes functions to hash typed data into EIP712-compliant messages, including struct hashing and building domain separator.

Built for and used in a few of my other projects. Hope it serves similar usefulness to others.
