### PR TITLE
Add zk-pipeline-doctor and zk-doctor-action under Developer Tools → Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ For library tooling (e.g. input generators, TypeScript implementations), refer t
 - [Lampe](https://github.com/reilabs/lampe) by Reilabs - formal verification of Noir programs with Lean
 - [zk-mutant](https://github.com/mutorium/zk-mutant) - mutation testing for Noir programs
 - [noir-metrics](https://github.com/mutorium/noir-metrics) - source code metrics for Noir programs with machine-friendly JSON outputs
+- [zk-pipeline-doctor](https://github.com/Battam1111/zk-pipeline-doctor) - multi-language CI/CD audit CLI: detects Noir projects (via `nargo.toml`) and runs six health detectors (language conventions, tests, CI, docs, security, reproducibility), emitting a Markdown / JSON report with a prioritized fix list. Also supports Compact, Leo, Cairo, and RISC Zero. MIT
+- [zk-doctor-action](https://github.com/Battam1111/zk-doctor-action) - GitHub Action wrapping `zk-pipeline-doctor` for one-line CI integration. Optional threshold gating and PR-comment mode. MIT
 
 ### Proving Backends
 


### PR DESCRIPTION
## What this adds

Two open-source (MIT) tools that help Noir projects keep their CI/audit hygiene high:

**1. [zk-pipeline-doctor](https://github.com/Battam1111/zk-pipeline-doctor)** — a multi-language CLI that detects ZK projects (via `nargo.toml`, `Cargo.toml`, `leo.toml`, `Scarb.toml`, etc.) and runs six independent health detectors:

- **Language** — ecosystem detection and toolchain conventions (Noir, Compact, Leo, Cairo, RISC Zero)
- **Tests** — test count, framework signals, ratio of test code to source
- **CI** — workflow files, matrix coverage, key signals
- **Docs** — README sections, CONTRIBUTING, examples folder
- **Security** — dependency pinning, no committed secrets, sensitive-file patterns
- **Reproducibility** — lockfile presence, fixed toolchain versions

The output is a weighted overall score plus a prioritized fix list with concrete commands (not generic suggestions). Built specifically with multi-ZK-ecosystem support in mind.

**2. [zk-doctor-action](https://github.com/Battam1111/zk-doctor-action)** — a composite GitHub Action wrapping the CLI. Five minutes to install on any Noir project, optional `threshold` input that fails CI below a score gate, optional `comment-on-pr` mode that posts the audit report inline. Marketplace release `v1.0.0`.

Both are MIT-licensed, no telemetry, no recurring cost, no proprietary backend. The detector engine has 13 tests passing and is self-audited in CI.

## Why "Security"

The closest existing entries are `noir-metrics` (code metrics) and `Lampe` (formal verification). `zk-pipeline-doctor` is complementary — it focuses on *project hygiene* rather than circuit correctness or static analysis: are tests present, is CI gating new code, is the toolchain pinned, are dependencies fixed. These six signals together are what reviewers look for first when triaging a ZK repo.

## Anything else

Happy to move the entries elsewhere if "Security" isn't the right home — they could plausibly sit under their own "Auditing" or "CI" subsection of Developer Tools. Just suggest where you'd prefer.

Thanks for maintaining this list! 🙏
