### PR TITLE
Add Noir ZK Identity Proof tutorial under Blog Posts & Articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ A curated list of resources for learning and programming in Noir.
 
 ### Blog Posts & Articles
 
+- [Building a Zero-Knowledge Identity Proof in Noir](https://battam1111.github.io/midnight-zk-cookbook/tutorials/noir-identity-proof.html) - hands-on ~3,500-word tutorial: design a circuit that proves a user owns a private credential (hash of national ID, age > 18, etc.) without revealing the underlying data; covers threat model, constraints/witnesses/public inputs, complete compilable Noir code, on-chain verifier integration, and common pitfalls (over-constraint, malleability, replay)
 - [Understanding the Technical Aspects of Aztec and Noir](https://hackmd.io/XZX9_pZ8Q1aa_ySDPeQopg)
 - Noir 101 for Solidity devs in ([English](https://mirror.xyz/crisgarner.eth/IRRxnP-HVP-7qLZ-bTI2HRpKTmSRPCDl-Q6gm2NTj4g)) and ([Spanish](https://mirror.xyz/crisgarner.eth/Iek7PhbhU4WpIJ6eixFq80_7R6czH7fbdCoN0Bd7NfI))
 - [Privacy-preserving KYC with Noir](https://medium.com/@tisura/privacy-preserving-kyc-57002ab8d3f2)


### PR DESCRIPTION
## What this adds

A new ~3,500-word hands-on tutorial under Learning → Blog Posts & Articles:

[Building a Zero-Knowledge Identity Proof in Noir](https://battam1111.github.io/midnight-zk-cookbook/tutorials/noir-identity-proof.html)

The tutorial walks a developer who's done hello-world in Noir but never a real circuit through:

1. **Problem statement + threat model** — what we're proving, what we're hiding, what could leak
2. **Circuit design** — constraints, witnesses, public inputs, why each choice
3. **Complete Noir code** — compilable example
4. **Proof generation + on-chain verification** — including the Aztec-style verifier contract integration
5. **Common pitfalls** — over-constraint, malleability, replay attacks
6. **Testing with nargo + edge cases**

Ends with a verification checklist a reviewer can use before deploying.

This is the kind of post I wanted to read when I was getting beyond hello-world myself — concrete, with code that compiles, and with the dangerous edges flagged. Companion to the broader [ZK Cookbook](https://battam1111.github.io/midnight-zk-cookbook/) which is now 17 tutorials across 5 ecosystems.

Happy to move it under Interactive Tutorials or Examples if Blog Posts feels off — let me know!
