### PR TITLE
Added Noir RLWE Gadgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ A curated list of resources for programming with Noir.
 #### Encryption
 
 - [ECDH](https://github.com/privacy-scaling-explorations/zk-kit.noir/tree/main/packages/ecdh) - simple implementation of ECDH on the Baby Jubjub curve
+- [RLWE Gadgets](https://github.com/aryaethn/noir-rlwe-gadgets) - gadgets for verifying Ring-LWE / BFV encryption correctness (secret-key and public-key) in-circuit via Schwartz-Zippel, with an on-chain UltraHonk verifier (UNAUDITED)
+
 
 #### Signatures
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A curated list of resources for programming with Noir.
 #### Encryption
 
 - [ECDH](https://github.com/privacy-scaling-explorations/zk-kit.noir/tree/main/packages/ecdh) - simple implementation of ECDH on the Baby Jubjub curve
-- [RLWE Gadgets](https://github.com/aryaethn/noir-rlwe-gadgets) - gadgets for verifying Ring-LWE / BFV encryption correctness (secret-key and public-key) in-circuit via Schwartz-Zippel, with an on-chain UltraHonk verifier (UNAUDITED)
+- [RLWE Gadgets](https://github.com/aryaethn/noir-rlwe-gadgets) - verify Ring-LWE / BFV encryption via Schwartz-Zippel random-evaluation, useful for verifiable lattice-based cryptography and FHE
 
 
 #### Signatures


### PR DESCRIPTION
Added Noir RLWE Gadgets (https://github.com/aryaethn/noir-rlwe-gadgets) 
Gadgets for verifying Ring-LWE / BFV encryption correctness (secret-key and public-key) in-circuit via Schwartz-Zippel, with an on-chain UltraHonk verifier (UNAUDITED)